### PR TITLE
fix(detailedView): When a user adds a resource label and URL, they show ...

### DIFF
--- a/app/js/components/quickview/ResourcesTab.jsx
+++ b/app/js/components/quickview/ResourcesTab.jsx
@@ -47,9 +47,7 @@ var ResourcesTab = React.createClass({
 
     renderOtherResources: function () {
         var resources = _.compact(this.props.listing.docUrls.map(function (doc) {
-            if (doc.name !== 'User Manual' && doc.name !== 'API Documentation') {
-                return <p><a target="_blank" href={ doc.url }>{ doc.name }</a></p>;
-            }
+          return <p><a target="_blank" href={ doc.url }>{ doc.name }</a></p>;
         }));
 
         return resources.length ? resources : <EmptyFieldValue text="None available" />;


### PR DESCRIPTION
...up on the resource tab of the detail view. API Documentation and User Guide were explicitely prevented before, but that has been removed. #149