### PR TITLE
fix(createEdit): Original fix for this issue broke the error messages…

### DIFF
--- a/app/js/components/createEdit/validation/listing.js
+++ b/app/js/components/createEdit/validation/listing.js
@@ -146,8 +146,12 @@ function validate (instance, options, type) {
         errors = {};
     if (validation.errors) {
         validation.errors.forEach(function (e) {
-            var path = e.path.join('.');
-            errors[path] = true;
+            if(e.path[0] === 'tags'){
+                errors[e.path[0]] = true;
+            }
+            else{
+                errors[e.path.join('.')] = true;
+            }
         });
     }
 


### PR DESCRIPTION
… in the resources section of createEdit. This fixes the error messages for the tags and does not affect the new resources error message. #157