### PR TITLE
fix(Help): Fixed invalid role for appsmall stewards #518

### DIFF
--- a/app/js/components/NavBar/helpmodal.jsx
+++ b/app/js/components/NavBar/helpmodal.jsx
@@ -22,6 +22,7 @@ var HelpModal = React.createClass({
         var UserRole = {
           USER: 0,
           ORG_STEWARD: 1,
+          APPS_MALL_STEWARD: 2,
           ADMIN: 2
         };
 


### PR DESCRIPTION
This fixes the issue where if you were logged in as an `APPS_MALL_STEWARD` help would be broken in the modal.
@clarkjefcoat @SOAP1914 please review.