### PR TITLE
fix(Create Edit): Fix display of associated agency

### DIFF
--- a/app/js/components/createEdit/index.jsx
+++ b/app/js/components/createEdit/index.jsx
@@ -411,7 +411,7 @@ var ListingForm = React.createClass({
                     itemForm={ ScreenshotForm }/>
 
                 <h2 id={f.ownersAndContacts.id}>Owner Information and Contacts</h2>
-                <Select2Input id={f.orgs.id} { ...p('agency') }
+                <Select2Input id={f.orgs.id} { ...p('agencyShort') }
                     options={ getOptionsForSimpleLists(organizations) }/>
                 <OwnerInput id={f.owners.id} { ...p('owners') } listing={listing}
                     ownerSetter={ownerSetter} />


### PR DESCRIPTION
This PR depends on https://github.com/ozone-development/ozp-react-commons/pull/48

This is a follow up on ticket #533.  The previous fix made the appropriate text display, but broke the saving of changes to the field.