### PR TITLE
(fix) 617 display wrong notification

### DIFF
--- a/app/js/components/NavBar/notificationsmodal.jsx
+++ b/app/js/components/NavBar/notificationsmodal.jsx
@@ -63,7 +63,7 @@ var NotificationsModal = React.createClass({
     makeSidebar: function() {
       var notis = this.state.notificationList.slice();
 
-      return notis.reverse().map((n, i) => {
+      return notis.map((n, i) => {
         var date = new Date(n.createdDate);
         var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'June', 'July', 'Aug', 'Sept', 'Oct', 'Nov', 'Dec'];
         var formattedDate = (months[date.getMonth() + 1]) + ' ' + date.getDate() + ', ' +  date.getFullYear();


### PR DESCRIPTION
Fix for issue #617 where the see more notifications when clicked on displayed the wrong notification in the right of the pop up window. 